### PR TITLE
Added config constant k_allowed_tcpdf_tags

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -62,6 +62,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('k_small_ratio')->defaultValue(2/3)->end()
                         ->scalarNode('k_thai_topchars')->defaultTrue()->end()
                         ->scalarNode('k_tcpdf_calls_in_html')->defaultFalse()->end()
+                        ->scalarNode('k_allowed_tcpdf_tags')->defaultValue('')->end()
                         ->scalarNode('k_tcpdf_external_config')->defaultTrue()->end()
                         ->scalarNode('k_tcpdf_throw_exception_error')->defaultTrue()->end()
 


### PR DESCRIPTION
The configuration constant k_allowed_tcpdf_tags was missed.
The fix added the new name to the configuration file.